### PR TITLE
Add github actions for release and building manual artifacts

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -1,0 +1,26 @@
+name: Build and Upload Artifact
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Package the extension
+      run: npx vsce package
+
+    - name: Upload VSIX to workflow run's assets
+      uses: actions/upload-artifact@v3
+      with:
+        name: titlebar-colour.vsix
+        path: ./titlebar-colour-*.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 name: Build and Upload on Release
-
 on:
   release:
     types: [created]
@@ -21,10 +20,16 @@ jobs:
     - name: Package the extension
       run: npx vsce package
 
+    - name: Get the generated VSIX file name
+      id: get_vsix
+      run: echo "::set-output name=vsix_file::$(ls *.vsix)"
+
     - name: Upload VSIX to release
       uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./titlebar-colour-*.vsix
-        asset_name: titlebar-colour.vsix
+        asset_path: ${{ steps.get_vsix.outputs.vsix_file }}
+        asset_name: ${{ steps.get_vsix.outputs.vsix_file }}
         asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Build and Upload on Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Package the extension
+      run: npx vsce package
+
+    - name: Upload VSIX to release
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./titlebar-colour-*.vsix
+        asset_name: titlebar-colour.vsix
+        asset_content_type: application/octet-stream


### PR DESCRIPTION
- Building a manual artifact tested [here](https://github.com/nunofgs/vscode-titlebar-colour/actions/runs/11518477426).
- Building on release tested [here](https://github.com/nunofgs/vscode-titlebar-colour/actions/runs/11518692168/job/32066005888) and here's the [resulting release](https://github.com/nunofgs/vscode-titlebar-colour/releases/tag/0.1).