### PR TITLE
Install docs and todos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
 # Change Log
 
-All notable changes to the "titlebar-colour" extension will be documented in this file.
-
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
-## [Unreleased]
-
-- Initial release
+Please see the [Releases page](https://github.com/richdawe-cio/vscode-titlebar-colour/releases) in GitHub.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,14 @@
 # titlebar-colour
 
-Ensure each VSCode window has a titlebar with a different colour.
+A VSCode extension that ensures that each VSCode window has a titlebar with a different colour.
 
-## Bundle
+## Downloading a Bundle
 
-See [Publishing Extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) for more information about building and publishing bundles.
+You can download releases of the extension from the [Releases page](https://github.com/richdawe-cio/vscode-titlebar-colour/releases). Download the `.vsix` file for a release.
 
-To generate a bundle (`.vsix` file) that you can install into VSCode locally, run the following command:
+If you want to build the bundle from source, please see a later section.
 
-```bash
-npx vsce package
-```
-
-This will build a file with a name like `titlebar-colour-0.0.2.vsix`.
-
-## Install Bundle
+## Installing a Bundle
 
 "
 For users, to install a .vsix file in VS Code:
@@ -25,3 +19,15 @@ For users, to install a .vsix file in VS Code:
 "
 
 On VSCode on macOS, you have to click on the breadcrumbs (...) in the top-right of the Extensions pane, in order to see the "Install from VSIX..." option.
+
+## Building a Bundle
+
+See [Publishing Extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) for more information about building and publishing bundles.
+
+To generate a bundle (`.vsix` file) that you can install into VSCode locally, run the following command:
+
+```bash
+npx vsce package
+```
+
+This will build a file with a name like `titlebar-colour-0.0.3.vsix`.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,3 @@
+- [ ] Build an extension bundle using esbuild, per the docs for [VSCode: Bundling Extensions](https://code.visualstudio.com/api/working-with-extensions/bundling-extension)
+
+- [ ] Add a config option to disable the automatic colour change, so that it can be disabled per workspace in `.vscode/settings.json`.


### PR DESCRIPTION
Now we have automatically-built bundles on release, link to the releases pages in the docs.

Also add some TODOs for later work.